### PR TITLE
ci: Add GoReleaser workflow for releases and PR checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: GoReleaser
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write # to create releases
+  pull-requests: read # to read PR metadata
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # This is required for GoReleaser to fetch all tags and generate a changelog
+          fetch-depth: 0
+
+      - name: Set up mise
+        uses: jdx/mise-action@v2
+
+      - name: Run GoReleaser build check (Pull Request)
+        if: github.event_name == 'pull_request'
+        run: goreleaser build --snapshot --clean
+        # The 'build' command only builds the binaries and archives,
+        # but does not release them. '--snapshot' is used for test runs.
+
+      - name: Run GoReleaser release (Tag Push)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          # 'distribution: goreleaser' is required for the action to use the
+          # GoReleaser binary installed by a previous step (e.g., mise).
+          distribution: goreleaser
+          # The version will be determined by the git tag.
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit adds a GitHub Actions workflow for GoReleaser.

- On pull requests to main, it runs `goreleaser build` to test that the release process is healthy.
- On pushes to tags starting with 'v', it runs `goreleaser release` to create a full GitHub release.