### PR TITLE
feat: add ac subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,28 @@ Changes to the previous channel.
 sbot tv channel-down "Living Room TV"
 ```
 
+### Air Conditioner Commands
+
+#### `ac on [DEVICE_NAME_OR_ID] --temperature [TEMP] --mode [MODE] --fan-speed [SPEED]`
+
+Turns on an Air Conditioner with specified settings. Temperature is required.
+
+*   `--temperature`, `-t`: Temperature in Celsius.
+*   `--mode`, `-m`: `auto`, `cool`, `dry`, `fan`, `heat` (default: `auto`).
+*   `--fan-speed`, `-f`: `auto`, `low`, `medium`, `high` (default: `auto`).
+
+```bash
+sbot ac on "Bedroom AC" -t 25 --mode cool --fan-speed medium
+```
+
+#### `ac off [DEVICE_NAME_OR_ID]`
+
+Turns off an Air Conditioner.
+
+```bash
+sbot ac off "Bedroom AC"
+```
+
 ### Scene Commands
 
 #### `scene list`

--- a/cmd/ac.go
+++ b/cmd/ac.go
@@ -1,0 +1,19 @@
+/*
+Copyright © 2025 YOUR NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// acCmd represents the ac command
+var acCmd = &cobra.Command{
+	Use:   "ac",
+	Short: "Manage Air Conditioner devices",
+	Long:  `Provides subcommands to manage and control Air Conditioner devices.`,
+}
+
+func init() {
+	rootCmd.AddCommand(acCmd)
+}

--- a/cmd/ac_off.go
+++ b/cmd/ac_off.go
@@ -1,0 +1,47 @@
+/*
+Copyright © 2025 YOUR NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/yteraoka/sbot/client"
+)
+
+// acOffCmd represents the off command
+var acOffCmd = &cobra.Command{
+	Use:   "off [DEVICE_NAME_OR_ID]",
+	Short: "Turn an Air Conditioner off",
+	Long:  `Sends the "turnOff" command to a specific Air Conditioner.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		token := os.Getenv("SWITCHBOT_TOKEN")
+		secret := os.Getenv("SWITCHBOT_CLIENT_SECRET")
+		if token == "" || secret == "" {
+			return fmt.Errorf("SWITCHBOT_TOKEN and SWITCHBOT_CLIENT_SECRET must be set")
+		}
+
+		nameOrID := args[0]
+		c := client.NewClient(token, secret)
+
+		deviceID, err := c.GetDeviceID(nameOrID)
+		if err != nil {
+			return err
+		}
+
+		err = c.SendCommand(deviceID, "turnOff", "default")
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Turned off Air Conditioner %s (%s).\n", nameOrID, deviceID)
+		return nil
+	},
+}
+
+func init() {
+	acCmd.AddCommand(acOffCmd)
+}

--- a/cmd/ac_on.go
+++ b/cmd/ac_on.go
@@ -1,0 +1,79 @@
+/*
+Copyright © 2025 YOUR NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/yteraoka/sbot/client"
+)
+
+var temperature int
+var mode string
+var fanSpeed string
+
+// acOnCmd represents the on command
+var acOnCmd = &cobra.Command{
+	Use:   "on [DEVICE_NAME_OR_ID]",
+	Short: "Turn an Air Conditioner on with specified settings",
+	Long: `Turns on an Air Conditioner using the 'setAll' command.
+
+You must specify the temperature. Mode and fan speed are optional.
+
+Valid modes: auto, cool, dry, fan, heat
+Valid fan speeds: auto, low, medium, high`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		token := os.Getenv("SWITCHBOT_TOKEN")
+		secret := os.Getenv("SWITCHBOT_CLIENT_SECRET")
+		if token == "" || secret == "" {
+			return fmt.Errorf("SWITCHBOT_TOKEN and SWITCHBOT_CLIENT_SECRET must be set")
+		}
+
+		nameOrID := args[0]
+
+		modeMap := map[string]string{"auto": "1", "cool": "2", "dry": "3", "fan": "4", "heat": "5"}
+		fanSpeedMap := map[string]string{"auto": "1", "low": "2", "medium": "3", "high": "4"}
+
+		modeValue, ok := modeMap[strings.ToLower(mode)]
+		if !ok {
+			return fmt.Errorf("invalid mode: %s. valid modes are auto, cool, dry, fan, heat", mode)
+		}
+
+		fanSpeedValue, ok := fanSpeedMap[strings.ToLower(fanSpeed)]
+		if !ok {
+			return fmt.Errorf("invalid fan speed: %s. valid speeds are auto, low, medium, high", fanSpeed)
+		}
+
+		parameter := fmt.Sprintf("%d,%s,%s,on", temperature, modeValue, fanSpeedValue)
+
+		c := client.NewClient(token, secret)
+
+		deviceID, err := c.GetDeviceID(nameOrID)
+		if err != nil {
+			return err
+		}
+
+		err = c.SendCommand(deviceID, "setAll", parameter)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Turned on Air Conditioner %s (%s) with settings: temp=%d, mode=%s, fan=%s.\n", nameOrID, deviceID, temperature, mode, fanSpeed)
+		return nil
+	},
+}
+
+func init() {
+	acCmd.AddCommand(acOnCmd)
+	acOnCmd.Flags().IntVarP(&temperature, "temperature", "t", 0, "Temperature in Celsius (required)")
+	acOnCmd.Flags().StringVarP(&mode, "mode", "m", "auto", "Mode (auto, cool, dry, fan, heat)")
+	acOnCmd.Flags().StringVarP(&fanSpeed, "fan-speed", "f", "auto", "Fan speed (auto, low, medium, high)")
+	if err := acOnCmd.MarkFlagRequired("temperature"); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
Add a new subcommand `ac` to control Air Conditioner devices.

This subcommand includes the following features:
- Turn on with specified temperature, mode, and fan speed.
- Turn off.
