### PR TITLE
feat: add run-customize command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ Turns a device off. You can specify the device by its name or ID.
 sbot off "Bedroom Bot"
 ```
 
+#### `run-customize [DEVICE_NAME_OR_ID] [BUTTON_NAME]`
+
+Executes a custom button on an infrared remote.
+
+```bash
+sbot run-customize "Living Room TV" "Menu"
+```
+
 ### Color Bulb Commands
 
 #### `bulb set brightness [DEVICE_NAME_OR_ID] [LEVEL]`

--- a/cmd/run_customize.go
+++ b/cmd/run_customize.go
@@ -1,0 +1,49 @@
+/*
+Copyright © 2025 YOUR NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/yteraoka/sbot/client"
+)
+
+// runCustomizeCmd represents the run-customize command
+var runCustomizeCmd = &cobra.Command{
+	Use:   "run-customize [DEVICE_NAME_OR_ID] [BUTTON_NAME]",
+	Short: "Execute a custom button on an infrared remote",
+	Long:  `Sends a "customize" command to a specific infrared device to execute a custom button (DIY button).`,
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		token := os.Getenv("SWITCHBOT_TOKEN")
+		secret := os.Getenv("SWITCHBOT_CLIENT_SECRET")
+		if token == "" || secret == "" {
+			return fmt.Errorf("SWITCHBOT_TOKEN and SWITCHBOT_CLIENT_SECRET must be set")
+		}
+
+		nameOrID := args[0]
+		buttonName := args[1]
+
+		c := client.NewClient(token, secret)
+
+		deviceID, err := c.GetDeviceID(nameOrID)
+		if err != nil {
+			return err
+		}
+
+		err = c.SendCustomizeCommand(deviceID, buttonName)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Executed custom button '%s' on device %s (%s).\n", buttonName, nameOrID, deviceID)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(runCustomizeCmd)
+}


### PR DESCRIPTION
Add a new command `run-customize` to execute custom buttons on infrared remotes.

This command sends a "customize" command type to the SwitchBot API, allowing users to trigger actions that are not available through the standard command set.
