### PR TITLE
refactor: rename scene exec to scene run

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,12 +159,12 @@ List all registered scenes.
 sbot scene list
 ```
 
-#### `scene exec [SCENE_NAME_OR_ID]`
+#### `scene run [SCENE_NAME_OR_ID]`
 
-Executes a specific scene.
+Runs a specific scene.
 
 ```bash
-sbot scene exec "Movie Time"
+sbot scene run "Movie Time"
 ```
 
 ## Shell Completion

--- a/cmd/scene_run.go
+++ b/cmd/scene_run.go
@@ -11,11 +11,11 @@ import (
 	"github.com/yteraoka/sbot/client"
 )
 
-// sceneExecCmd represents the exec command
-var sceneExecCmd = &cobra.Command{
-	Use:   "exec [SCENE_NAME_OR_ID]",
-	Short: "Execute a scene",
-	Long:  `Executes a specific scene, specified by its name or ID.`,
+// sceneRunCmd represents the run command
+var sceneRunCmd = &cobra.Command{
+	Use:   "run [SCENE_NAME_OR_ID]",
+	Short: "Run a scene",
+	Long:  `Runs a specific scene, specified by its name or ID.`,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		token := os.Getenv("SWITCHBOT_TOKEN")
@@ -43,5 +43,5 @@ var sceneExecCmd = &cobra.Command{
 }
 
 func init() {
-	sceneCmd.AddCommand(sceneExecCmd)
+	sceneCmd.AddCommand(sceneRunCmd)
 }


### PR DESCRIPTION
For consistency with other commands, the `scene exec` command has been renamed to `scene run`.

This change improves the usability and predictability of the CLI.
