### PR TITLE
feat: webhookサブコマンドを改善

### DIFF
--- a/cmd/webhook_get.go
+++ b/cmd/webhook_get.go
@@ -11,12 +11,11 @@ import (
 	"github.com/yteraoka/sbot/client"
 )
 
-// webhookDeleteCmd represents the delete command
-var webhookDeleteCmd = &cobra.Command{
-	Use:   "delete [URL]",
-	Short: "Delete a webhook",
-	Long:  `Deletes the webhook for your SwitchBot account.`,
-	Args:  cobra.ExactArgs(1),
+// webhookGetCmd represents the get command
+var webhookGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get the webhook URL",
+	Long:  `Gets the webhook URL for your SwitchBot account.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		token := os.Getenv("SWITCHBOT_TOKEN")
 		secret := os.Getenv("SWITCHBOT_CLIENT_SECRET")
@@ -24,20 +23,18 @@ var webhookDeleteCmd = &cobra.Command{
 			return fmt.Errorf("SWITCHBOT_TOKEN and SWITCHBOT_CLIENT_SECRET must be set")
 		}
 
-		webhookURL := args[0]
-
 		c := client.NewClient(token, secret)
 
-		err := c.DeleteWebhook(webhookURL)
+		webhookURL, err := c.GetWebhook()
 		if err != nil {
 			return err
 		}
 
-		fmt.Println("Successfully deleted webhook.")
+		fmt.Println(webhookURL)
 		return nil
 	},
 }
 
 func init() {
-	webhookCmd.AddCommand(webhookDeleteCmd)
+	webhookCmd.AddCommand(webhookGetCmd)
 }

--- a/cmd/webhook_update.go
+++ b/cmd/webhook_update.go
@@ -11,6 +11,8 @@ import (
 	"github.com/yteraoka/sbot/client"
 )
 
+var enable bool
+
 // webhookUpdateCmd represents the update command
 var webhookUpdateCmd = &cobra.Command{
 	Use:   "update [URL]",
@@ -28,7 +30,7 @@ var webhookUpdateCmd = &cobra.Command{
 
 		c := client.NewClient(token, secret)
 
-		err := c.SetupWebhook(webhookURL)
+		err := c.UpdateWebhook(webhookURL, enable)
 		if err != nil {
 			return err
 		}
@@ -40,4 +42,5 @@ var webhookUpdateCmd = &cobra.Command{
 
 func init() {
 	webhookCmd.AddCommand(webhookUpdateCmd)
+	webhookUpdateCmd.Flags().BoolVar(&enable, "enable", true, "Enable or disable the webhook")
 }


### PR DESCRIPTION
webhookサブコマンドに以下の変更を追加しました。

- `create`: リクエストボディに`action`と`deviceList`を追加
- `update`: webhookのURLと有効/無効を更新できるように修正
- `delete`: URLを指定してwebhookを削除できるように修正
- `get`: webhookのURLを取得する機能を追加