### PR TITLE
ci: replace deprecated app-id with client-id in create-github-app-token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           # 自分のリポジトリと Tap リポジトリの両方に権限を絞る（任意）
           owner: ${{ github.repository_owner }}


### PR DESCRIPTION
## Summary

- `actions/create-github-app-token` の `app-id` input が deprecated になった ([actions/create-github-app-token#353](https://github.com/actions/create-github-app-token/pull/353))
- `.github/workflows/release.yml` の `app-id` を `client-id` に変更

## Test plan

- [ ] PR マージ後、次回リリース時に Token 生成ステップが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)