### PR TITLE
fix: rename homebrew tap repository to homebrew-cask

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: |
             sbot
-            homebrew-tap
+            homebrew-cask
 
       - name: Run GoReleaser release (Tag Push)
         if: startsWith(github.ref, 'refs/tags/')

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,7 +50,7 @@ changelog:
 homebrew_casks:
   - repository:
       owner: yteraoka
-      name: homebrew-tap
+      name: homebrew-cask
       token: "{{ .Env.GITHUB_TOKEN }}"
       pull_request:
         enabled: false


### PR DESCRIPTION
## Summary
- GoReleaser and release workflow referenced the `homebrew-tap` repository, which has been renamed to `homebrew-cask`.
- Updates both `.goreleaser.yaml` and `.github/workflows/release.yml` to point to the new repository name.

## Test plan
- [ ] Verify a tagged release run successfully creates/updates the cask in `yteraoka/homebrew-cask`

🤖 Generated with [Claude Code](https://claude.com/claude-code)